### PR TITLE
Add mobile hazard reporting web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# OSM Alerts
+
+A simple mobile-friendly web application for reporting road hazards using OpenStreetMap and Leaflet.
+
+Open `index.html` in a browser (requires location permissions) to view the map, track your location and report hazards such as roadworks, potholes or crashes.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OSM Hazards</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2uHKb5pt0uE7oGtLiNfXtzeLlT23D3ttAnGx33U=" crossorigin=""/>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="map"></div>
+    <button id="report-btn" aria-label="Report Hazard">+</button>
+    <div id="hazard-menu" class="hidden">
+        <button data-type="roadworks">🚧 Road Works</button>
+        <button data-type="pothole">🕳️ Pothole</button>
+        <button data-type="crash">🚗 Crash</button>
+    </div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o8ljTDMb3LY28vJA69WvGVvHFLlcpC+nRcPpX9AP1fM=" crossorigin=""></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,98 @@
+let map;
+let userMarker;
+let currentPos;
+const hazardKey = 'hazardReports';
+
+function initMap() {
+    map = L.map('map');
+    map.setView([0,0], 15);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    if (navigator.geolocation) {
+        navigator.geolocation.watchPosition(onLocationFound, onLocationError, {
+            enableHighAccuracy: true,
+            maximumAge: 10000,
+            timeout: 10000
+        });
+    } else {
+        alert('Geolocation is not supported by your browser');
+    }
+}
+
+function onLocationFound(position) {
+    currentPos = [position.coords.latitude, position.coords.longitude];
+    if (!userMarker) {
+        userMarker = L.marker(currentPos).addTo(map);
+    } else {
+        userMarker.setLatLng(currentPos);
+    }
+    map.setView(currentPos);
+}
+
+function onLocationError() {
+    alert('Unable to retrieve your location');
+}
+
+function loadHazards() {
+    const stored = localStorage.getItem(hazardKey);
+    if (!stored) return [];
+    try {
+        return JSON.parse(stored);
+    } catch(e) {
+        return [];
+    }
+}
+
+function saveHazard(hazard) {
+    const hazards = loadHazards();
+    hazards.push(hazard);
+    localStorage.setItem(hazardKey, JSON.stringify(hazards));
+}
+
+function showHazards() {
+    const hazards = loadHazards();
+    hazards.forEach(h => {
+        const icon = getHazardIcon(h.type);
+        L.marker([h.lat, h.lng], {icon}).addTo(map);
+    });
+}
+
+function getHazardIcon(type) {
+    const emojis = {
+        roadworks: '🚧',
+        pothole: '🕳️',
+        crash: '🚗'
+    };
+    return L.divIcon({html: emojis[type], className: 'hazard-icon', iconSize: [24,24]});
+}
+
+function reportHazard(type) {
+    if (!currentPos) return;
+    const hazard = {lat: currentPos[0], lng: currentPos[1], type, time: Date.now()};
+    saveHazard(hazard);
+    const icon = getHazardIcon(type);
+    L.marker(currentPos, {icon}).addTo(map);
+}
+
+function setupUI() {
+    const btn = document.getElementById('report-btn');
+    const menu = document.getElementById('hazard-menu');
+    btn.addEventListener('click', () => {
+        menu.classList.toggle('hidden');
+    });
+    menu.addEventListener('click', e => {
+        if (e.target.dataset.type) {
+            reportHazard(e.target.dataset.type);
+            menu.classList.add('hidden');
+        }
+    });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    initMap();
+    showHazards();
+    setupUI();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,54 @@
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+}
+
+#map {
+    height: 100vh;
+    width: 100%;
+}
+
+#report-btn {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background-color: #007bff;
+    color: #fff;
+    font-size: 32px;
+    border: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    cursor: pointer;
+}
+
+#hazard-menu {
+    position: absolute;
+    bottom: 80px;
+    right: 20px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    padding: 10px;
+}
+
+#hazard-menu.hidden {
+    display: none;
+}
+
+#hazard-menu button {
+    display: block;
+    width: 100%;
+    margin: 5px 0;
+    padding: 8px;
+    font-size: 16px;
+}
+
+.hazard-icon {
+    font-size: 24px;
+    text-align: center;
+    line-height: 24px;
+}


### PR DESCRIPTION
## Summary
- create a simple Leaflet map page that tracks current location
- add floating button to report road hazards
- provide hazard menu for roadworks, pothole, and crash
- store reports in browser localStorage and show markers
- document usage in README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6865baab43448331aadbff9fe3cf4615