### PR TITLE
Improve instructions and error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,14 @@
 
 A simple mobile-friendly web application for reporting road hazards using OpenStreetMap and Leaflet.
 
-Open `index.html` in a browser (requires location permissions) to view the map, track your location and report hazards such as roadworks, potholes or crashes.
+Because the app relies on the browser's geolocation API, the page must be served via
+HTTP/HTTPS (browsers block geolocation on plain `file://` URLs). Run a local server
+and then open `http://localhost:8000/index.html`:
+
+```bash
+python3 -m http.server 8000
+```
+
+Once loaded, allow location access to see your position on the map. Use the `+`
+button to report roadworks, potholes or crashes – these markers are stored in your
+browser's local storage.

--- a/script.js
+++ b/script.js
@@ -32,8 +32,9 @@ function onLocationFound(position) {
     map.setView(currentPos);
 }
 
-function onLocationError() {
-    alert('Unable to retrieve your location');
+function onLocationError(err) {
+    console.error('Location error:', err);
+    alert('Unable to retrieve your location. Make sure the page is served via HTTP/HTTPS and that location access is allowed.');
 }
 
 function loadHazards() {


### PR DESCRIPTION
## Summary
- clarify that the page must be served via HTTP and show how
- provide a clearer geolocation error message with console output

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865bb7fde048331acacbf648413a477